### PR TITLE
Bug #91: Починить поиск

### DIFF
--- a/protected/models/Search.php
+++ b/protected/models/Search.php
@@ -51,7 +51,7 @@ class Search extends CComponent
   protected function getContent()
   {
     $parameters = array(
-      'text' => urlencode($this->query),
+      'text' => $this->query,
       'xml' => 'yes',
       'p' => $this->page - 1,
     );


### PR DESCRIPTION
В методе Search::getContent() текст запроса кодировался 2 раза: при подготовке массива параметров и в функции http_build_query.
